### PR TITLE
Added batching and retry configuration

### DIFF
--- a/src/GenerateNotice.IntegrationTests/GenerateNotice.IntegrationTests.csproj
+++ b/src/GenerateNotice.IntegrationTests/GenerateNotice.IntegrationTests.csproj
@@ -18,9 +18,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 

--- a/src/GenerateNotice.IntegrationTests/RootCommandTests.cs
+++ b/src/GenerateNotice.IntegrationTests/RootCommandTests.cs
@@ -62,10 +62,16 @@ namespace GenerateNotice.IntegrationTests
             result.ExitCode.Should().Be(0);
             result.StdErr.Should().BeEmpty();
             result.StdOutAsString.Should().ContainAll(
-                "NuGet dependencies (212):",
-                "NPM dependencies (0):",
+                "NuGet dependency count = 212",
+                "NPM dependency count = 0",
                 "OK",
-                "NOTICE file saved to '");
+                "NOTICE file saved to '",
+                "Starting batch 0 (0..100)",
+                "Completed batch 0",
+                "Starting batch 1 (100..200)",
+                "Completed batch 1",
+                "Starting batch 2 (200..212)",
+                "Completed batch 2");
 
             File.Exists(outputFilePath).Should().BeTrue();
             var notice = File.ReadAllText(outputFilePath);
@@ -103,10 +109,18 @@ namespace GenerateNotice.IntegrationTests
             result.ExitCode.Should().Be(0);
             result.StdErr.Should().BeEmpty();
             result.StdOutAsString.Should().ContainAll(
-                "NuGet dependencies (0):",
-                "NPM dependencies (393):",
+                "NuGet dependency count = 0",
+                "NPM dependency count = 393",
                 "OK",
-                "NOTICE file saved to '");
+                "NOTICE file saved to '",
+                "Starting batch 0 (0..100)",
+                "Completed batch 0",
+                "Starting batch 1 (100..200)",
+                "Completed batch 1",
+                "Starting batch 2 (200..300)",
+                "Completed batch 2",
+                "Starting batch 3 (300..393)",
+                "Completed batch 3");
 
             File.Exists(outputFilePath).Should().BeTrue();
             var notice = File.ReadAllText(outputFilePath);

--- a/src/GenerateNotice.IntegrationTests/RootCommandTests.cs
+++ b/src/GenerateNotice.IntegrationTests/RootCommandTests.cs
@@ -66,11 +66,11 @@ namespace GenerateNotice.IntegrationTests
                 "NPM dependency count = 0",
                 "OK",
                 "NOTICE file saved to '",
-                "Starting batch 0 (0..100)",
+                "Starting batch 0 (0..99)",
                 "Completed batch 0",
-                "Starting batch 1 (100..200)",
+                "Starting batch 1 (100..199)",
                 "Completed batch 1",
-                "Starting batch 2 (200..212)",
+                "Starting batch 2 (200..211)",
                 "Completed batch 2");
 
             File.Exists(outputFilePath).Should().BeTrue();
@@ -113,13 +113,13 @@ namespace GenerateNotice.IntegrationTests
                 "NPM dependency count = 393",
                 "OK",
                 "NOTICE file saved to '",
-                "Starting batch 0 (0..100)",
+                "Starting batch 0 (0..99)",
                 "Completed batch 0",
-                "Starting batch 1 (100..200)",
+                "Starting batch 1 (100..199)",
                 "Completed batch 1",
-                "Starting batch 2 (200..300)",
+                "Starting batch 2 (200..299)",
                 "Completed batch 2",
-                "Starting batch 3 (300..393)",
+                "Starting batch 3 (300..392)",
                 "Completed batch 3");
 
             File.Exists(outputFilePath).Should().BeTrue();

--- a/src/GenerateNotice.IntegrationTests/packages.lock.json
+++ b/src/GenerateNotice.IntegrationTests/packages.lock.json
@@ -19,12 +19,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[17.1.0, )",
-        "resolved": "17.1.0",
-        "contentHash": "MVKvOsHIfrZrvg+8aqOF5dknO/qWrR1sWZjMPQ1N42MKMlL/zQL30FQFZxPeWfmVKWUWAOmAHYsqB5OerTKziw==",
+        "requested": "[17.3.0, )",
+        "resolved": "17.3.0",
+        "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "17.1.0",
-          "Microsoft.TestPlatform.TestHost": "17.1.0"
+          "Microsoft.CodeCoverage": "17.3.0",
+          "Microsoft.TestPlatform.TestHost": "17.3.0"
         }
       },
       "Microsoft.SourceLink.GitHub": {
@@ -39,23 +39,19 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.8, )",
-        "resolved": "2.2.8",
-        "contentHash": "BzxcfLaOZ25g8usreCBwFvpzH9LcR56pSkMbERO718cTQyAChXBYVuNIU3uK9stCcUWdXxIYl4WloiIu/C/PMQ==",
+        "requested": "[2.2.10, )",
+        "resolved": "2.2.10",
+        "contentHash": "KOc7XVNM0Q5GrTAx4RhxTgwdt9O5gOqSzmLpUMyl9ywa6vvUNFVQ9nCjtEE7qDQW54MZdc82e287PzZDc7yQtA==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1",
+          "Newtonsoft.Json": "10.0.3",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
         }
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[2.2.8, )",
-        "resolved": "2.2.8",
-        "contentHash": "phUoHuGTuw9T5yekxPHLLLq8jE56yufmh2yPlJq1IfkT4a3tYZ2htkeTlnQmzmJP3hI5xYhlqwiHcy3JqVt/OA==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1",
-          "System.Diagnostics.TextWriterTraceListener": "4.3.0"
-        }
+        "requested": "[2.2.10, )",
+        "resolved": "2.2.10",
+        "contentHash": "JZRVXKq19uRhkj8MuzsU8zJhPV2JV3ZToFPAIg+BU53L1L9mNDfm9jXerdRfbrE4HBcf2M54Ij80zPOdlha3+Q=="
       },
       "Nerdbank.GitVersioning": {
         "type": "Direct",
@@ -70,30 +66,30 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "17.1.0",
-        "contentHash": "0N/ZJ71ncCxQWhgtkEYKOgu2oMHa8h1tsOUbhmIKXF8UwtSUCe4vHAsJ3DVcNWRwNfQzSTy263ZE+QF6MdIhhQ=="
+        "resolved": "17.3.0",
+        "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
-        "resolved": "4.0.1",
-        "contentHash": "17h8b5mXa87XYKrrVqdgZ38JefSUqLChUQpXgSnpzsM0nDOhE40FTeNWOJ/YmySGV6tG6T8+hjz6vxbknHJr6A==",
+        "resolved": "4.3.0",
+        "contentHash": "P+MBhIM0YX+JqROuf7i306ZLJEjQYA9uUyRDE+OqwUI5sh41e2ZbPQV3LfAPh+29cmceE1pUffXsGfR4eMY3KA==",
         "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Dynamic.Runtime": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11"
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Threading": "4.3.0"
         }
       },
       "Microsoft.Extensions.Configuration": {
@@ -376,8 +372,8 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "17.1.0",
-        "contentHash": "OMo/FYnKGy3lZEK0gfitskRM3ga/YBt6MyCyFPq0xNLeybGOQ6HnYNAAvzyePo5WPuMiw3LX+HiuRWNjnas1fA==",
+        "resolved": "17.3.0",
+        "contentHash": "6NRzi6QbmWV49Psf8A9z1LTJU4nBrlJdCcDOUyD4Ttm1J2wvksu98GlV+52CkxtpgNsUjGr9Mv1Rbb1/dB06yQ==",
         "dependencies": {
           "NuGet.Frameworks": "5.11.0",
           "System.Reflection.Metadata": "1.6.0"
@@ -385,10 +381,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "17.1.0",
-        "contentHash": "JS0JDLniDhIzkSPLHz7N/x1CG8ywJOtwInFDYA3KQvbz+ojGoT5MT2YDVReL1b86zmNRV8339vsTSm/zh0RcMg==",
+        "resolved": "17.3.0",
+        "contentHash": "uOJALDWtKXZkISKuNI7kOlRi/lk2CqXZtLkNS0Ei+RXqRUjUpCsjAPYSP+DJ/a4QwJ5cI9CVF52vtajnGOaEpw==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "17.1.0",
+          "Microsoft.TestPlatform.ObjectModel": "17.3.0",
           "Newtonsoft.Json": "9.0.1"
         }
       },
@@ -455,31 +451,15 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "9.0.1",
-        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "resolved": "10.0.3",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww==",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1",
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Dynamic.Runtime": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Serialization.Primitives": "4.1.1",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Text.RegularExpressions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XDocument": "4.0.11"
+          "Microsoft.CSharp": "4.3.0",
+          "NETStandard.Library": "1.6.1",
+          "System.ComponentModel.TypeConverter": "4.3.0",
+          "System.Runtime.Serialization.Formatters": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0"
         }
       },
       "NuGet.Frameworks": {
@@ -654,6 +634,33 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Collections.NonGeneric": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections.Specialized": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Epx8PoVZR0iuOnJJDzp7pWvdfMMOAvpUo95pC4ScH2mJuXkKA2Y4aR3cG9qt2klHgSons1WFh4kcGW7cSXvrxg==",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
       "System.CommandLine": {
         "type": "Transitive",
         "resolved": "2.0.0-beta4.22272.1",
@@ -675,6 +682,46 @@
         "contentHash": "ux2eUA/syF+JtlpMDc/Lsd6PBIBuwjH3AvHnestoh5uD0WKT5b+wkQxDWVCqp9qgVjMBTLNhX19ZYFtenunt9A==",
         "dependencies": {
           "System.CommandLine": "2.0.0-beta4.22272.1"
+        }
+      },
+      "System.ComponentModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VyGn1jGRZVfxnh8EdvDCi71v3bMXrsu8aYJOwoV7SNDLVhiEqwP86pPMyRGsDsxhXAm2b3o9OIqeETfN5qfezw==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "j8GUkCpM8V4d4vhLIIoBLGey2Z5bCkMVNjEZseyAlm4n5arcsJOeI3zkUP+zvZgzsbLTYh4lYeP/ZD/gdIAPrw==",
+        "dependencies": {
+          "System.ComponentModel": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.TypeConverter": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "16pQ6P+EdhcXzPiEK4kbA953Fu0MNG2ovxTZU81/qsCd1zPRsKc3uif5NgvllCY598k6bI0KUyKW8fanlfaDQg==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Collections.Specialized": "4.3.0",
+          "System.ComponentModel": "4.3.0",
+          "System.ComponentModel.Primitives": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
         }
       },
       "System.Configuration.ConfigurationManager": {
@@ -771,24 +818,23 @@
       },
       "System.Dynamic.Runtime": {
         "type": "Transitive",
-        "resolved": "4.0.11",
-        "contentHash": "db34f6LHYM0U0JpE+sOmjar27BnqTVkbLJhgfwMpTdgTigG/Hna3m2MYVwnFzGGKnEJk2UXFuoVTr8WUbU91/A==",
+        "resolved": "4.3.0",
+        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
         "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Emit": "4.0.1",
-          "System.Reflection.Emit.ILGeneration": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11"
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
         }
       },
       "System.Globalization": {
@@ -1175,13 +1221,25 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "KT591AkTNFOTbhZlaeMVvfax3RqhH1EJlcwF50Wm7sfnBLuHiOeZRRKrr1ns3NESkM20KPZ5Ol/ueMq5vg4QoQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
       "System.Runtime.Serialization.Primitives": {
         "type": "Transitive",
-        "resolved": "4.1.1",
-        "contentHash": "HZ6Du5QrTG8MNJbf4e4qMO3JRAkIboGT5Fk804uZtg3Gq516S7hAqTm2UZKUHa7/6HUGdVy3AqMQKbns06G/cg==",
+        "resolved": "4.3.0",
+        "contentHash": "Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
         "dependencies": {
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0"
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
         }
       },
       "System.Security.Cryptography.Algorithms": {
@@ -1451,6 +1509,23 @@
           "System.Globalization": "4.3.0",
           "System.IO": "4.3.0",
           "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XmlDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "lJ8AxvkX7GQxpC6GFCeBj8ThYVyQczx2+f/cWHJU8tjS7YfI6Cv6bon70jVEgs2CiFbmmM8b9j1oZVx0dSI2Ww==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Runtime.Extensions": "4.3.0",

--- a/src/GenerateNotice.Nuget/build/Azure.Deployments.Internal.GenerateNotice.targets
+++ b/src/GenerateNotice.Nuget/build/Azure.Deployments.Internal.GenerateNotice.targets
@@ -1,5 +1,10 @@
-<Project TreatAsLocalProperty="_GenerateNoticeAssetFileParameter;_GenerateNoticeNpmListFileParameter;_PreambleFileParameter">
+<Project TreatAsLocalProperty="_GenerateNoticeAssetFileParameter;_GenerateNoticeNpmListFileParameter;_PreambleFileParameter;_RetryCountParameter;_BatchSizeParameter">
   
+  <PropertyGroup>
+    <GenerateNoticeRetryCount Condition="'$(GenerateNoticeRetryCount)' == ''">3</GenerateNoticeRetryCount>
+    <GenerateNoticeBatchSize Condition="'$(GenerateNoticeBatchSize)' == ''">100</GenerateNoticeBatchSize>
+  </PropertyGroup>
+
   <Target Name="GenerateNotice" 
           AfterTargets="$(GenerateNoticeAfterTargets)" 
           BeforeTargets="$(GenerateNoticeBeforeTargets)" 
@@ -15,10 +20,12 @@
       <_GenerateNoticeAssetFileParameter Condition="@(GenerateNoticeAssetFile) != ''">--asset-files @(GenerateNoticeAssetFile,' ')</_GenerateNoticeAssetFileParameter>
       <_GenerateNoticeNpmListFileParameter Condition="@(GenerateNoticeNpmListJsonFile) != ''">--npm-list-json-files @(GenerateNoticeNpmListJsonFile,' ')</_GenerateNoticeNpmListFileParameter>
       <_PreambleFileParameter Condition="'$(GenerateNoticePreambleFile)' != ''">--preamble-file $(GenerateNoticePreambleFile)</_PreambleFileParameter>
+      <_RetryCountParameter>--retry-count $(GenerateNoticeRetryCount)</_RetryCountParameter>
+      <_BatchSizeParameter>--batch-size $(GenerateNoticeBatchSize)</_BatchSizeParameter>
     </PropertyGroup>
 
     <Exec 
-      Command="dotnet $(GenerateNoticeAssemblyPath) $(_GenerateNoticeAssetFileParameter) $(_GenerateNoticeNpmListFileParameter) --output-file $(GenerateNoticeOutputPath) $(_PreambleFileParameter)"
+      Command="dotnet $(GenerateNoticeAssemblyPath) $(_GenerateNoticeAssetFileParameter) $(_GenerateNoticeNpmListFileParameter) --output-file $(GenerateNoticeOutputPath) $(_PreambleFileParameter) $(_RetryCountParameter) $(_BatchSizeParameter)"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 </Project>

--- a/src/GenerateNotice/Program.cs
+++ b/src/GenerateNotice/Program.cs
@@ -53,17 +53,22 @@ namespace OSS.GenerateNotice
                 IsRequired = false
             };
 
-            var batchSizeOption = new Option<int?>("--batch-size", $"Numbers of libraries to submit on a single API call. Batches will be submitted sequentially. The default is {DefaultBatchSize}.")
+            var batchSizeOption = new Option<int?>("--batch-size", $"Number of libraries to submit on a single API call. Batches will be submitted sequentially. The default is {DefaultBatchSize}.")
             {
                 IsRequired = false
             };
 
-            var retryCount = new Option<int?>("--retry-count", $"Number of retries for each API call. The default is {DefaultRetryCount}.");
+            var retryCountOption = new Option<int?>("--retry-count", $"Number of retries for each API call. The default is {DefaultRetryCount}.")
+            {
+                IsRequired = false
+            };
 
             rootCommand.AddOption(assetFilesOption);
             rootCommand.AddOption(npmListJsonFilesOption);
             rootCommand.AddOption(outputOption);
             rootCommand.AddOption(preambleFileOption);
+            rootCommand.AddOption(batchSizeOption);
+            rootCommand.AddOption(retryCountOption);
 
             try
             {
@@ -80,7 +85,7 @@ namespace OSS.GenerateNotice
                     );
 
                     await MainInternal(arguments);
-                }, assetFilesOption, npmListJsonFilesOption, outputOption, preambleFileOption, batchSizeOption, retryCount);
+                }, assetFilesOption, npmListJsonFilesOption, outputOption, preambleFileOption, batchSizeOption, retryCountOption);
 
                 return await rootCommand.InvokeAsync(args);
             }

--- a/src/GenerateNotice/Program.cs
+++ b/src/GenerateNotice/Program.cs
@@ -118,6 +118,8 @@ namespace OSS.GenerateNotice
                 .ToImmutableArray();
             Console.WriteLine($"NPM dependency count = {npmDependencies.Length}");
 
+            Console.WriteLine($"Total count = {nugetDependencies.Length + npmDependencies.Length}");
+
             var client = new HttpClient();
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -132,7 +134,7 @@ namespace OSS.GenerateNotice
             {
                 var request = requests[i];
 
-                Console.WriteLine($"Starting batch {i} ({processedCoordinates}..{processedCoordinates + request.Coordinates.Length})");
+                Console.WriteLine($"Starting batch {i} ({processedCoordinates}..{processedCoordinates + request.Coordinates.Length - 1})");
 
                 responses.Add(await InvokeNoticeApi(client, request, arguments.RetryCount));
 


### PR DESCRIPTION
Apparently batch size correlates with failure rate in the notice generation API. Based on the API owner's recommendation, I added batching with default batch size set to 100. Also added ability to customize retry and updated some packages to latest versions.